### PR TITLE
Add option to dump all certificates which are starting with a common String

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Special thanks to them!
   + [Image choice](#image-choice)
   + [Basic setup](#basic-setup)
   + [Dump all certificates](#dump-all-certificates)
+  + [Dump all certificates starting with](#dump-certificates-starting-with-string)
   + [Automatic container restart](#automatic-container-restart)
   + [Change ownership of certificate and key files](#change-ownership-of-certificate-and-key-files)
   + [Extract multiple domains](#extract-multiple-domains)
@@ -72,6 +73,21 @@ services:
     # Don't set DOMAIN
     # environment:
     # - DOMAIN=example.org
+```
+### Dump certificates starting with STRING
+Set the environment variable `DOMAIN_STARTS_WITH` instead of `DOMAIN`.
+```yaml
+version: '3.7'
+
+services:
+  certdumper:
+    image: humenius/traefik-certs-dumper:latest
+    volumes:
+    - ./traefik/acme:/traefik:ro
+    - ./output:/output:rw
+    # Don't set DOMAIN
+     environment:
+     - DOMAIN_STARTS_WITH=STRING
 ```
 
 ### Automatic container restart

--- a/bin/dump.sh
+++ b/bin/dump.sh
@@ -92,7 +92,8 @@ dump() {
     fi
   elif [[ ! (-z "${DOMAIN_STARTS_WITH}") ]]; then
     local diff_available=false
-    for i in $(basename `find ${workdir} -type d -name ${DOMAIN_STARTS_WITH}'*'`) ; do
+    for certdir in `find ${workdir} -type d -name ${DOMAIN_STARTS_WITH}'*'`; do
+      i=`basename ${certdir}`
       if
         [[ -f ${workdir}/${i}/cert.pem && -f ${workdir}/${i}/key.pem ]]
       then

--- a/bin/dump.sh
+++ b/bin/dump.sh
@@ -92,7 +92,7 @@ dump() {
     fi
   elif [[ ! (-z "${DOMAIN_STARTS_WITH}") ]]; then
     local diff_available=false
-    for i in `find ${workdir} -type d -name ${DOMAIN_STARTS_WITH}'*'` ; do
+    for i in $(basename `find ${workdir} -type d -name ${DOMAIN_STARTS_WITH}'*'`) ; do
       if
         [[ -f ${workdir}/${i}/cert.pem && -f ${workdir}/${i}/key.pem ]]
       then

--- a/bin/dump.sh
+++ b/bin/dump.sh
@@ -368,9 +368,12 @@ else
   log "(e.g.: humenius/traefik-certs-dumper:latest)"
 fi
 
-if [[ -z "${DOMAIN}" ]]; then
+if [[ (-z "${DOMAIN}") && (-z "${DOMAIN_STARTS_WITH}") ]]; then
   # die "Environment variable DOMAIN mustn't be empty. Exiting..." 1
-  log "Environment variable DOMAIN empty. Will dump all certificates possible..."
+  log "Environment variable DOMAIN and DOMAIN_STARTS_WITH empty. Will dump all certificates possible..."
+elif [[ ! (-z "${DOMAIN_STARTS_WITH}") ]]; then
+  log "Environment variable DOMAIN_STARTS_WITH is set."
+  log "Will dump all certificates starting with ${DOMAIN_STARTS_WITH}"
 else
   log "Got value of DOMAIN: ${DOMAIN}. Splitting values."
   IFS=',' read -ra DOMAINS <<< "$DOMAIN"

--- a/bin/dump.sh
+++ b/bin/dump.sh
@@ -23,7 +23,7 @@ dump() {
     --dest /tmp/work \
     --source /traefik/acme.json >/dev/null
 
-  if [[ -z "${DOMAIN}" ]]; then
+  if [[ (-z "${DOMAIN}") && (-z "${DOMAIN_STARTS_WITH}") ]]; then
     local diff_available=false
     local workdir_subdirs=(${workdir}/*/)
     for subdir in "${workdir_subdirs[@]}" ; do
@@ -43,6 +43,9 @@ dump() {
             diff_available=true
             local dir=${outputdir}/${i}
             mkdir -p "${dir}" && mv ${workdir}/${i}/*.pem "${dir}"
+            log "Create domains file for '${i}'"
+            openssl x509 -noout -ext subjectAltName -in "${dir}/cert.pem" | \
+              sed '1d;s/ //g;s/DNS://g;s/,/ /g' > "${dir}/domains"
           fi
         else
           err "Certificates for domain '${i}' don't exist. Omitting..."
@@ -72,6 +75,9 @@ dump() {
           diff_available=true
           local dir=${outputdir}/${i}
           mkdir -p "${dir}" && mv ${workdir}/${i}/*.pem "${dir}"
+          log "Create domains file for '${i}'"
+          openssl x509 -noout -ext subjectAltName -in "${dir}/cert.pem" | \
+            sed '1d;s/ //g;s/DNS://g;s/,/ /g' > "${dir}/domains"
         fi
       else
         err "Certificates for domain '${i}' don't exist. Omitting..."
@@ -84,7 +90,7 @@ dump() {
       restart_containers
       restart_services
     fi
-  elif [[ -z "${DOMAIN_STARTS_WITH}" ]]; then
+  elif [[ ! (-z "${DOMAIN_STARTS_WITH}") ]]; then
     local diff_available=false
     for i in `find ${workdir} -type d -name ${DOMAIN_STARTS_WITH}'*'` ; do
       if
@@ -100,6 +106,9 @@ dump() {
           diff_available=true
           local dir=${outputdir}/${i}
           mkdir -p "${dir}" && mv ${workdir}/${i}/*.pem "${dir}"
+          log "Create domains file for '${i}'"
+          openssl x509 -noout -ext subjectAltName -in "${dir}/cert.pem" | \
+            sed '1d;s/ //g;s/DNS://g;s/,/ /g' > "${dir}/domains"
         fi
       else
         err "Certificates for domain '${i}' don't exist. Omitting..."

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,8 @@ RUN \
     apk add --no-cache \
         inotify-tools \
         util-linux \
-        bash
+        bash \
+        openssl
 
 COPY bin/dump.sh /usr/bin/dump
 COPY bin/healthcheck.sh /usr/bin/healthcheck


### PR DESCRIPTION
This pull request includes commits for exporting all certificates with a common String.
When setting the variable DOMAIN_STARTS_WITH to e.g. "mail" the certificates mail.olqs.de and mail.worli.info will be dumped, but not www.olqs.de
Additionally a file domains is generated in the certificate subdir which contains a space seperated list of the SAN entries of the certificate.