### PR TITLE
Added support for PKCS12 format

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ services:
 
 ### Merging private key and public certificate in one PKCS12 file
 
-Some applications like [Plex](https://www.plex.tv/de/) need both private key and public certificate to be concatenated to one PKCS12 file. In this case, you can set the environment variable `COMBINE_PKCS12` to any value (In Docker, no value means not setting. Must be atleast "".). Each time `traefik-certs-dumper` dumps the certificates for specified `DOMAIN`, this script will create a file named `cert.p12` in each domain's folder respectively. The password can be set with the environment variable `PKCS12_PASSWORD` which has support for docker secrets with the `PKCS12_PASSWORD_FILE` environment variable. If none of those is set, the password will be empty.
+Some applications like [Plex](https://www.plex.tv/de/) need both private key and public certificate to be concatenated to one PKCS12 file. In this case, you can set the environment variable `COMBINE_PKCS12=yes`. Each time `traefik-certs-dumper` dumps the certificates for specified `DOMAIN`, this script will create a file named `cert.p12` in each domain's folder respectively. The password can be set with the environment variable `PKCS12_PASSWORD`. If you want to use Docker Secrets instead, use the environment variable `PKCS12_PASSWORD_FILE`. Note that `PKCS12_PASSWORD` has higher priority. If none of those is set, the password will be empty.
 
 ```yaml
 version: '3.7'
@@ -195,7 +195,7 @@ services:
     secrets:
       - pkcs12_password
     environment:
-      DOMAIN: $DOMAINNAME0
+      DOMAIN: example.com
       PKCS12_PASSWORD_FILE: /run/secrets/pkcs12_password
       COMBINE_PKCS12: "true"
       OVERRIDE_UID: 1000

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ services:
     volumes:
       - /docker-data/traefik2:/traefik:ro
       - /docker-data/certdumb:/output:rw
-      - /var/run/docker.sock:/var/run/docker.sock:ro # Only needed if restarting containers (use Docker Socket Proxy instead)
+      - /var/run/docker.sock:/var/run/docker.sock:ro
     secrets:
       - pkcs12_password
     environment:

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ services:
     environment:
       DOMAIN: example.com
       PKCS12_PASSWORD_FILE: /run/secrets/pkcs12_password
-      COMBINE_PKCS12: "true"
+      COMBINE_PKCS12: "yes"
       OVERRIDE_UID: 1000
       OVERRIDE_GID: 1000
 

--- a/README.md
+++ b/README.md
@@ -189,8 +189,8 @@ services:
     container_name: traefik_certdumper
     network_mode: none
     volumes:
-      - /docker-data/traefik2:/traefik:ro
-      - /docker-data/certdumb:/output:rw
+      - ./traefik/acme:/traefik:ro
+      - ./output:/output:rw
       - /var/run/docker.sock:/var/run/docker.sock:ro
     secrets:
       - pkcs12_password

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -6,7 +6,8 @@ RUN \
     apk add --no-cache \
         inotify-tools \
         util-linux \
-        bash
+        bash \
+        openssl
 
 COPY bin/dump.sh /usr/bin/dump
 COPY bin/healthcheck.sh /usr/bin/healthcheck

--- a/alpine/Dockerfile.aarch64
+++ b/alpine/Dockerfile.aarch64
@@ -9,7 +9,8 @@ RUN \
     apk add --no-cache \
         inotify-tools \
         util-linux \
-        bash
+        bash \
+        openssl
 
 COPY bin/dump.sh /usr/bin/dump
 COPY bin/healthcheck.sh /usr/bin/healthcheck

--- a/alpine/Dockerfile.armhf
+++ b/alpine/Dockerfile.armhf
@@ -8,7 +8,8 @@ RUN \
     apk add --no-cache \
         inotify-tools \
         util-linux \
-        bash
+        bash \
+        openssl
 
 COPY bin/dump.sh /usr/bin/dump
 COPY bin/healthcheck.sh /usr/bin/healthcheck

--- a/bin/dump.sh
+++ b/bin/dump.sh
@@ -131,7 +131,7 @@ combine_pem() {
 }
 
 combine_pkcs12() {
-  if [[ -z ${COMBINE_PKCS12+x} ]]; then
+  if [[ ! "${COMBINE_PKCS12}" = yes ]]; then
     return
   fi
 

--- a/bin/dump.sh
+++ b/bin/dump.sh
@@ -131,7 +131,7 @@ combine_pem() {
 }
 
 combine_pkcs12() {
-  if [[ ! "${COMBINE_PKCS12}" = yes ]]; then
+  if [[ "${COMBINE_PKCS12}" != yes ]]; then
     return
   fi
 

--- a/bin/dump.sh
+++ b/bin/dump.sh
@@ -150,7 +150,7 @@ combine_pkcs12() {
     done
   else
     if [[ -f ${outputdir}/cert.pem && -f ${outputdir}/key.pem ]]; then
-      log "Combining key and cert to pkcs12 file"
+      log "Combining key and cert to PKCS12 file"
       openssl pkcs12 -export -in ${outputdir}/cert.pem -inkey ${outputdir}/key.pem -out ${outputdir}/cert.p12 -password pass:"${PKCS12_PASSWORD}"
     fi
   fi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,8 @@ RUN \
     apk add --no-cache \
         inotify-tools \
         util-linux \
-        bash
+        bash \
+        openssl
 
 COPY bin/dump.sh /usr/bin/dump
 COPY bin/healthcheck.sh /usr/bin/healthcheck

--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -8,7 +8,8 @@ RUN \
     apk add --no-cache \
         inotify-tools \
         util-linux \
-        bash
+        bash \
+        openssl
 
 COPY bin/dump.sh /usr/bin/dump
 COPY bin/healthcheck.sh /usr/bin/healthcheck

--- a/docker/Dockerfile.armhf
+++ b/docker/Dockerfile.armhf
@@ -8,7 +8,8 @@ RUN \
     apk add --no-cache \
         inotify-tools \
         util-linux \
-        bash
+        bash \
+        openssl
 
 COPY bin/dump.sh /usr/bin/dump
 COPY bin/healthcheck.sh /usr/bin/healthcheck


### PR DESCRIPTION
This pullrequest adds the ability to combine the cert and key into a PKCS12 certificate. The reason I implemented it was my Plex setup. I added an section for this in the README how it can be configured.

PS: Sorry for the smal changes in formatting. I think I hit the autoformat key.