### PR TITLE
Bugfix for check command exists

### DIFF
--- a/bin/dump.sh
+++ b/bin/dump.sh
@@ -247,17 +247,17 @@ log() {
   echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $*"
 }
 
-check_docker_cmd() {
-  local __ret=$1
+check_cmd() {
+  local cmd=$1
 
-  [[ -x "$(command -v docker)" ]]
+  #check command exist, but no output
+  command -v $1 >/dev/null 
+
   local _result=$?
-
   if ((_result == 1)); then
-
-    unset __ret
+    echo false
   else
-    eval "$__ret=true"
+    echo true
   fi
 }
 
@@ -333,8 +333,7 @@ parse_commandline() {
 
 parse_commandline "$@"
 
-_docker_available=
-check_docker_cmd _docker_available
+_docker_available=$(check_cmd docker)
 
 if [[ "${_docker_available}" = true ]]; then
   if [[ -z "${_arg_restart_containers}" ]]; then


### PR DESCRIPTION
in the current version, the check_docker_command is always returning false. So docker restart containers and or services is never going to work.

I've make little fix, and also introduce a new function to check any command exists.

This is also my very first pull request every on github (as far as I remember). So please, don't be angry if I don't do something right.