### PR TITLE
Added RSA key file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,16 @@ There are some environment variables if you want to customize various things ins
 | `CERTIFICATE_FILE_NAME` | `cert`               | `<filename>`  | The file name (without extension) of the generated certificates.            |
 | `CERTIFICATE_FILE_EXT`  | `.pem`               | `<extension>` | The file extension of the generated certificates.                           |
 | `COMBINE_PKCS12`        | unset                | `yes`         | If set to `yes`, an additional combined PKCS12 file is created.             |
+| `CONVERT_KEYS_TO_RSA`   | unset                | `yes`         | If set to `yes`, keys are created in RSA format also.             |
 | `DOMAIN`                | unset                | `<extension>` | Extract only for specified domains (comma-separated list) - instead of all. |
 | `OVERRIDE_UID`          | unset                | `<number>`    | Change ownership of certificate and key to given `UID`.                     |
 | `OVERRIDE_GID`          | unset                | `<number>`    | Change ownership of certificate and key to given `GID`.                     |
 | `PKCS12_PASSWORD`       | unset                | `<password>`  | Password for the combined PKCS12, see also `COMBINE_PKCS12`.                |
 | `PRIVATE_KEY_FILE_NAME` | `key`                | `<filename>`  | The file name (without extension) of the generated private keys.            |
 | `PRIVATE_KEY_FILE_EXT`  | `.pem`               | `<extension>` | The file extension of the generated private keys.                           |
+| `RSA_KEY_FILE_NAME`     | `rsakey`             | `<filename>`  | The file name (without extension) of the generated private keys in RSA format, see also `CONVERT_KEYS_TO_RSA`. |
+| `RSA_KEY_FILE_EXT`      | `.pem`               | `<extension>` | The file extension of the generated private keys in RSA format, see also `CONVERT_KEYS_TO_RSA`. | 
+
 
 See below examples for usage.
 

--- a/README.md
+++ b/README.md
@@ -277,6 +277,31 @@ secrets:
     file: /path/to/secret/PKCS12_PASSWORD
 ```
 
+### Convert keys in RSA format
+
+Some applications like [mySQL](https://www.mysql.com/) or [mariaDB](https://mariadb.org/) need their keys in RSA format. In this case, you can set the environment variable `CONVERT_KEYS_TO_RSA`. Each time `traefik-certs-dumper` dumps the certificates, this script will create a file named `rsakey.pem` in each domain's folder respectively. If required, this file name can be configured using the environment variables `RSA_KEY_FILE_NAME` und `RSA_KEY_FILE_EXT`.
+
+
+```yaml
+version: '3.7'
+
+services:
+  certdumper:
+    image: humenius/traefik-certs-dumper:latest
+    container_name: traefik_certdumper
+    network_mode: none
+    volumes:
+      - ./traefik/acme:/traefik:ro
+      - ./output:/output:rw
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      CONVERT_KEYS_TO_RSA: "yes"
+      RSA_KEY_FILE_NAME: "myrsa"
+      RSA_KEY_FILE_EXT: ".ext"
+
+```
+
+
 ## Help!
 
 If you need help using this image, have suggestions or want to report a problem, feel free to open an issue on GitHub!

--- a/bin/dump.sh
+++ b/bin/dump.sh
@@ -177,7 +177,7 @@ convert_keys_to_rsa() {
     local outputdir_subdirs=(${outputdir}/*/)
     for subdir in "${outputdir_subdirs[@]}"; do
       local i=$(basename "${subdir}" /)
-      if [[ -f ${outputdir}/${i}/cert.pem && -f ${outputdir}/${i}/key.pem ]]; then
+      if [[ -f "${outputdir}/${i}/${certificate_file}" && -f "${outputdir}/${i}/${privatekey_file}" ]]; then
         log "Converting key for domain ${i} to RSA key file"
         openssl rsa -in ${outputdir}/"${i}"/key.pem -out ${outputdir}/"${i}"/rsakey.pem
       fi

--- a/bin/dump.sh
+++ b/bin/dump.sh
@@ -179,7 +179,7 @@ convert_keys_to_rsa() {
       local i=$(basename "${subdir}" /)
       if [[ -f "${outputdir}/${i}/${certificate_file}" && -f "${outputdir}/${i}/${privatekey_file}" ]]; then
         log "Converting key for domain ${i} to RSA key file"
-        openssl rsa -in ${outputdir}/"${i}"/key.pem -out ${outputdir}/"${i}"/rsakey.pem
+        openssl rsa -in "${outputdir}/${i}/${privatekey_file}" -out "${outputdir}/${i}/rsakey.pem"
       fi
     done
   else

--- a/bin/dump.sh
+++ b/bin/dump.sh
@@ -183,7 +183,7 @@ convert_keys_to_rsa() {
       fi
     done
   else
-    if [[ -f ${outputdir}/cert.pem && -f ${outputdir}/key.pem ]]; then
+    if [[ -f "${outputdir}/${certificate_file}" && -f "${outputdir}/${privatekey_file}" ]]; then
       log "Converting key to RSA key file"
       openssl rsa -in ${outputdir}/"${i}"/key.pem -out ${outputdir}/"${i}"/rsakey.pem
     fi

--- a/bin/dump.sh
+++ b/bin/dump.sh
@@ -9,8 +9,11 @@ certificate_file_name=${CERTIFICATE_FILE_NAME:-cert}
 certificate_file_ext=${CERTIFICATE_FILE_EXT:-.pem}
 certificate_file=${certificate_file_name}${certificate_file_ext}
 privatekey_file_name=${PRIVATE_KEY_FILE_NAME:-key}
-privatekey_file_ext=${PRIVATEK_EY_FILE_EXT:-.pem}
+privatekey_file_ext=${PRIVATE_KEY_FILE_EXT:-.pem}
 privatekey_file=${privatekey_file_name}${privatekey_file_ext}
+rsakey_file_name=${RSA_KEY_FILE_NAME:-rsakey}
+rsakey_file_ext=${RSA_KEY_FILE_EXT:-.pem}
+rsakey_file=${rsakey_file_name}${rsakey_file_ext}
 
 
 ###############################################
@@ -179,13 +182,13 @@ convert_keys_to_rsa() {
       local i=$(basename "${subdir}" /)
       if [[ -f "${outputdir}/${i}/${certificate_file}" && -f "${outputdir}/${i}/${privatekey_file}" ]]; then
         log "Converting key for domain ${i} to RSA key file"
-        openssl rsa -in "${outputdir}/${i}/${privatekey_file}" -out "${outputdir}/${i}/rsakey.pem"
+        openssl rsa -in "${outputdir}/${i}/${privatekey_file}" -out "${outputdir}/${i}/${rsakey_file}"
       fi
     done
   else
     if [[ -f "${outputdir}/${certificate_file}" && -f "${outputdir}/${privatekey_file}" ]]; then
       log "Converting key to RSA key file"
-      openssl rsa -in ${outputdir}/"${i}"/key.pem -out ${outputdir}/"${i}"/rsakey.pem
+      openssl rsa -in ${outputdir}/"${i}"/"${privatekey_file}" -out ${outputdir}/"${i}"/"${rsakey_file}"
     fi
   fi
 }

--- a/bin/dump.sh
+++ b/bin/dump.sh
@@ -61,7 +61,7 @@ dump() {
     if [[ "${diff_available}" = true ]]; then
       combine_pkcs12
       combine_pem
-      convert_key2rsa
+      convert_keys_to_rsa
       change_ownership
       restart_containers
       restart_services
@@ -90,7 +90,7 @@ dump() {
     if [[ "${diff_available}" = true ]]; then
       combine_pkcs12
       combine_pem
-      convert_key2rsa
+      convert_keys_to_rsa
       change_ownership
       restart_containers
       restart_services
@@ -108,7 +108,7 @@ dump() {
         mv ${workdir}/"${DOMAINS[0]}"/"${certificate_file}" ${workdir}/"${DOMAINS[0]}"/"${privatekey_file}" "${outputdir}/"
         combine_pkcs12
         combine_pem
-        convert_key2rsa
+        convert_keys_to_rsa
         change_ownership
         restart_containers
         restart_services
@@ -168,8 +168,8 @@ combine_pkcs12() {
   fi
 }
 
-convert_key2rsa() {
-  if [[ "${CONVERT_KEY2RSA}" != yes ]]; then
+convert_keys_to_rsa() {
+  if [[ "${CONVERT_KEYS_TO_RSA}" != yes ]]; then
     return
   fi
 


### PR DESCRIPTION
Hello everybody,

some applications (like `mysql` for example) need key files in RSA format. I prepared RSA key conversion using openssl. You can enable it by setting `CONVERT_KEY2RSA=yes`. 
If you think this is useful I'd update the README, too.

Best regards, and thanks for this fantastic tool.

Gregor