### PR TITLE
feat: Auto-updates and auto-releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,20 +3,23 @@
 version: 2
 
 updates:
-  - package-ecosystem: github-actions
-    directory: /
-    schedule: {interval: monthly}
-    reviewers: [kereis]
-    assignees: [kereis]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers: ["kereis"]
+    assignees: ["kereis"]
 
-  - package-ecosystem: docker
-    directory: /docker
-    schedule: {interval: monthly}
-    reviewers: [kereis]
-    assignees: [kereis]
+  - package-ecosystem: "docker"
+    directory: "/docker"
+    schedule: 
+      interval: "daily"
+    reviewers: ["kereis"]
+    assignees: ["kereis"]
 
-  - package-ecosystem: docker
-    directory: /alpine
-    schedule: {interval: monthly}
-    reviewers: [kereis]
-    assignees: [kereis]
+  - package-ecosystem: "docker"
+    directory: "/alpine"
+    schedule: 
+      interval: "daily"
+    reviewers: ["kereis"]
+    assignees: ["kereis"]

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,24 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    name: Auto-merge Dependabot updates
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'kereis/traefik-certs-dumper'
+    steps:
+      - name: Fetch metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2.3.0
+        with:
+          github-token: "${{ secrets.CR_PAT }}"
+        
+      - name: Enable auto-merge for pull request
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.CR_PAT }}

--- a/.github/workflows/dependabot-auto-release.yml
+++ b/.github/workflows/dependabot-auto-release.yml
@@ -28,6 +28,11 @@ jobs:
             exit 1
           fi
 
+          if (( $(git diff --name-only $last_release HEAD | grep -v '.github' | wc -l) == 0 )); then
+            echo "::warning title=Changes in .github only::The diff contains changes that are only related to GitHub Actions. Won't create release!"
+            exit 1
+          fi
+
           echo "LAST_RELEASE=$last_release" >> "$GITHUB_OUTPUT"
 
       - name: Bump patch version

--- a/.github/workflows/dependabot-auto-release.yml
+++ b/.github/workflows/dependabot-auto-release.yml
@@ -1,0 +1,75 @@
+name: Dependency updates auto-release
+
+on:
+  schedule:
+    - cron: '0 4 * * 6'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    name: Create release with auto-updates
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Make sure diff contains dependency updates only
+        id: deps_only_check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          last_release=$(gh release list --json tagName,isLatest --jq '.[] | select(.isLatest) | .tagName')
+          count_of_non_updates_commits=$(git log --pretty=format:"%an" HEAD...$last_release | uniq | grep -v '^dependabot\[bot\]$' | wc -l)
+          if (( $count_of_non_updates_commits > 0 )); then
+            echo "::error title=Non-update commits detected::git-log contains more than one commit that is not authored by dependabot[bot]. Please create release manually!"
+            exit 1
+          fi
+
+          echo "LAST_RELEASE=$last_release" >> "$GITHUB_OUTPUT"
+
+      - name: Bump patch version
+        id: new_version_tag
+        env:
+          LAST_RELEASE: ${{ steps.deps_only_check.outputs.LAST_RELEASE }}
+        run: |
+          major=$(echo "$LAST_RELEASE" | cut -d '.' -f 1)
+          minor=$(echo "$LAST_RELEASE" | cut -d '.' -f 2)
+          patch=$(echo "$LAST_RELEASE" | cut -d '.' -f 3)
+
+          echo "Version split - major: $major, minor: $minor, patch: $patch"
+
+          new_patch_version=$(echo "$patch + 1" | bc)
+          echo "New patch version: $new_patch_version"
+
+          new_version=$(echo "$major.$minor.$new_patch_version")
+          echo "::notice::Bumped version: $new_version"
+
+          echo "NEW_VERSION=$new_version" >> "$GITHUB_OUTPUT"
+
+      - name: Create release branch
+        id: create_release_branch
+        env: 
+          NEW_VERSION: ${{ steps.new_version_tag.outputs.NEW_VERSION }}
+        run: |
+          release_branch=release/$(echo "$NEW_VERSION" | cut -d 'v' -f 2)
+          git checkout -b $release_branch && git push origin HEAD
+
+          echo "::notice::Release branch: $release_branch"
+
+          echo "RELEASE_BRANCH=$release_branch" >> "$GITHUB_OUTPUT"
+
+      - name: Create new release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_VERSION: ${{ steps.new_version_tag.outputs.NEW_VERSION }}
+          RELEASE_BRANCH: ${{ steps.create_release_branch.outputs.RELEASE_BRANCH }}
+        run: |
+          gh release create "$NEW_VERSION" \
+            --title "$NEW_VERSION (auto-release)" \
+            --generate-notes \
+            --target "$RELEASE_BRANCH" \
+            --discussion-category "General" \
+            --latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,3 +129,40 @@ jobs:
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
           push: ${{ github.event_name == 'release' && github.event.action == 'created' }}
+
+  update-main-branch:
+    name: Update main (master) branch (by auto-release)
+    runs-on: ubuntu-latest
+    if: contains(github.event.release.name, 'auto-release')
+    needs:
+      - release
+      - release-alpine
+    permissions:
+      contents: write
+    env:
+      TAG: ${{ github.event.release.tag_name }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Update master branch
+        id: update_master_branch
+        run: |
+          release_branch=release/$(echo "$TAG" | cut -d 'v' -f 2)
+
+          git checkout master
+          git merge origin/$release_branch
+          git push
+
+          echo "RELEASE_BRANCH=$release_branch" >> "$GITHUB_OUTPUT"
+
+      - name: Update develop branch
+        run: |
+          git checkout develop
+          git merge master
+          git push
+
+      - name: Delete release branch
+        env:
+          RELEASE_BRANCH: ${{ steps.update_master_branch.outputs.RELEASE_BRANCH }}
+        run: git push origin --delete $RELEASE_BRANCH

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Special thanks to them!
 
 #### Releases
 
-We ship various flavors of this image as multi-arch builds: Docker (default) and Alpine. The versioning follows [SemVer](https://semver.org/). 
+We ship various flavors of this image as multi-arch builds: Docker (default) and Alpine. The versioning follows [SemVer](https://semver.org/).
 
 **Please note** that when using the `alpine` variant, using the container restart functionality won't work due to missing Docker installation and will be skipped.
 
@@ -70,6 +70,13 @@ We ship various flavors of this image as multi-arch builds: Docker (default) and
 |----------------------|--------------------------|
 | **Docker (default)** | `latest`, `x.x.x`, `x.x`, `x` |
 | **Alpine**           | `alpine`, `x.x.x-alpine`, `x.x-alpine`, `x-alpine` |
+
+
+Additionally, we run scheduled workflows that auto-release a new version if there are any dependency updates.
+
+- Dependabot PRs are auto-merged for each incoming Dependabot merge request
+- On each Sunday around 4:00 a.m. UTC, an auto-release workflow is triggered, which automatically creates a new release
+- Auto-released versions contain `(auto-release)` in the release's title
 
 #### Edge builds
 


### PR DESCRIPTION
- Auto-merges Dependabot updates for each incoming Dependabot merge request
- On each Sunday around 4:00 a.m., an auto-release workflow is triggered, which automatically creates a new release
  - If the diff between `HEAD` and latest tag contains commits that are not by `dependabot[bot]`, then the workflow aborts. In this case, we need to create a manual release because it appears that the diff may contain user features
  - Fetch latest tag and auto-bump version by one patch version
  - Create a new release in the same fashion as we would manually, but append `(auto-release)` to the title
- If a release is created by the auto-release workflow, then the release workflow also takes care of updating master and develop branch

## TODOs

- [x] Don't auto-release if the update commits only contain GitHub Actions updates
- [x] Update `README.md`