### PR TITLE
docs: Fix wrong env var in `ACME_FILE_PATH` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ services:
       - ./traefik/acme:/my/custom/path:ro
       - ./output:/output:rw
     environment:
-      - ACME_FILE: /my/custom/path/acme_the_second.json
+      - ACME_FILE_PATH=/my/custom/path/acme_the_second.json
 ```
 
 ### Automatic container restart


### PR DESCRIPTION
Closes #244 